### PR TITLE
DateTimeInterface should not be treated as strings

### DIFF
--- a/src/Stringifiers/ClusterStringifier.php
+++ b/src/Stringifiers/ClusterStringifier.php
@@ -53,7 +53,7 @@ final class ClusterStringifier implements Stringifier
         $stringifier = new self();
         $stringifier->setStringifiers([
             new TraversableStringifier($stringifier, $quoter),
-            new DateTimeStringifier($stringifier, 'c'),
+            new DateTimeStringifier($stringifier, $quoter, 'c'),
             new ThrowableStringifier($stringifier, $quoter),
             new StringableObjectStringifier($stringifier),
             new JsonSerializableStringifier($stringifier, $quoter),

--- a/src/Stringifiers/DateTimeStringifier.php
+++ b/src/Stringifiers/DateTimeStringifier.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace Respect\Stringifier\Stringifiers;
 
 use DateTimeInterface;
+use function get_class;
+use function sprintf;
+use Respect\Stringifier\Quoter;
 use Respect\Stringifier\Stringifier;
 
 /**
@@ -29,6 +32,11 @@ final class DateTimeStringifier implements Stringifier
     private $stringifier;
 
     /**
+     * @var Quoter
+     */
+    private $quoter;
+
+    /**
      * @var string
      */
     private $format;
@@ -37,11 +45,13 @@ final class DateTimeStringifier implements Stringifier
      * Initializes the stringifier.
      *
      * @param Stringifier $stringifier
+     * @param Quoter $quoter
      * @param string $format
      */
-    public function __construct(Stringifier $stringifier, string $format)
+    public function __construct(Stringifier $stringifier, Quoter $quoter, string $format)
     {
         $this->stringifier = $stringifier;
+        $this->quoter = $quoter;
         $this->format = $format;
     }
 
@@ -54,6 +64,13 @@ final class DateTimeStringifier implements Stringifier
             return null;
         }
 
-        return $this->stringifier->stringify($raw->format($this->format), $depth);
+        return $this->quoter->quote(
+            sprintf(
+                '[date-time] (%s: %s)',
+                get_class($raw),
+                $this->stringifier->stringify($raw->format($this->format), $depth + 1)
+            ),
+            $depth
+        );
     }
 }

--- a/tests/integration/stringify-object-dateTime.phpt
+++ b/tests/integration/stringify-object-dateTime.phpt
@@ -5,8 +5,16 @@ require 'vendor/autoload.php';
 use function Respect\Stringifier\stringify;
 
 $dateTime = DateTime::createFromFormat('Y-m-d\TH:i:sP', '2017-12-31T23:59:59+00:00');
+$dateTimeImmutable = DateTimeImmutable::createFromMutable($dateTime);
 
-echo stringify($dateTime);
+echo implode(
+    PHP_EOL,
+    [
+        stringify($dateTime),
+        stringify($dateTimeImmutable),
+    ]
+);
 ?>
 --EXPECT--
-"2017-12-31T23:59:59+00:00"
+`[date-time] (DateTime: "2017-12-31T23:59:59+00:00")`
+`[date-time] (DateTimeImmutable: "2017-12-31T23:59:59+00:00")`


### PR DESCRIPTION
They are objects, therefore they need to be represented as is.