### PR TITLE
Display private properties from parent classes

### DIFF
--- a/src/Stringifiers/ObjectStringifier.php
+++ b/src/Stringifiers/ObjectStringifier.php
@@ -56,7 +56,15 @@ final class ObjectStringifier implements Stringifier
      */
     private function getProperties(ReflectionObject $reflectionObject, object $object, int $depth): array
     {
-        $reflectionProperties = $reflectionObject->getProperties();
+        $reflectionProperties = [];
+        while ($reflectionObject) {
+            $reflectionProperties = [
+                ...$reflectionProperties,
+                ...$reflectionObject->getProperties(),
+            ];
+            $reflectionObject = $reflectionObject->getParentClass();
+        }
+
         if (count($reflectionProperties) === 0) {
             return [];
         }

--- a/tests/fixtures/ParentWithProperties.php
+++ b/tests/fixtures/ParentWithProperties.php
@@ -10,9 +10,7 @@ declare(strict_types=1);
 
 // phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 
-class WithProperties extends ParentWithProperties
+abstract class ParentWithProperties
 {
-    public bool $publicProperty = true;
-
-    protected int $protectedProperty = 42;
+    private string $privateProperty = 'something'; // @phpstan-ignore-line
 }

--- a/tests/unit/Stringifiers/ObjectStringifierTest.php
+++ b/tests/unit/Stringifiers/ObjectStringifierTest.php
@@ -13,6 +13,7 @@ namespace Respect\Stringifier\Test\Unit\Stringifiers;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use ReflectionObject;
 use Respect\Stringifier\Stringifiers\ObjectStringifier;
 use Respect\Stringifier\Test\Double\FakeQuoter;
@@ -22,6 +23,7 @@ use stdClass;
 use WithProperties;
 use WithUninitializedProperties;
 
+use function assert;
 use function sprintf;
 
 #[CoversClass(ObjectStringifier::class)]
@@ -71,6 +73,8 @@ final class ObjectStringifierTest extends TestCase
         $sut = new ObjectStringifier($stringifier, $quoter, self::MAXIMUM_DEPTH, self::MAXIMUM_NUMBER_OF_PROPERTIES);
 
         $relection = new ReflectionObject($raw);
+        $parentReflection = $relection->getParentClass();
+        assert($parentReflection instanceof ReflectionClass);
 
         $actual = $sut->stringify($raw, self::DEPTH);
         $expected = $quoter->quote(
@@ -79,7 +83,10 @@ final class ObjectStringifierTest extends TestCase
                 $relection->getName(),
                 $stringifier->stringify($relection->getProperty('publicProperty')->getValue($raw), self::DEPTH + 1),
                 $stringifier->stringify($relection->getProperty('protectedProperty')->getValue($raw), self::DEPTH + 1),
-                $stringifier->stringify($relection->getProperty('privateProperty')->getValue($raw), self::DEPTH + 1),
+                $stringifier->stringify(
+                    $parentReflection->getProperty('privateProperty')->getValue($raw),
+                    self::DEPTH + 1,
+                ),
             ),
             self::DEPTH
         );


### PR DESCRIPTION
Right now, when we stringify an object, we do not display the private properties of their parents, because we're only getting the properties of the current object.

This commit fixes that behavior, making sure we're displaying all the properties.