### PR TITLE
Remove redundant checks already covered by is_callable()

### DIFF
--- a/src/Handlers/CallableHandler.php
+++ b/src/Handlers/CallableHandler.php
@@ -62,11 +62,11 @@ final class CallableHandler implements Handler
             return $this->buildMethod(new ReflectionMethod($raw, '__invoke'), $raw, $depth);
         }
 
-        if (is_array($raw) && isset($raw[0], $raw[1]) && is_object($raw[0]) && is_string($raw[1])) {
+        if (is_array($raw) && is_object($raw[0])) {
             return $this->buildMethod(new ReflectionMethod($raw[0], $raw[1]), $raw[0], $depth);
         }
 
-        if (is_array($raw) && isset($raw[0], $raw[1]) && is_string($raw[0]) && is_string($raw[1])) {
+        if (is_array($raw)) {
             return $this->buildStaticMethod(new ReflectionMethod($raw[0], $raw[1]), $depth);
         }
 


### PR DESCRIPTION
…able()

Before this change, the array callable branches included explicit isset(), is_string(), and is_object() checks to narrow the type for static analysis. After updating PHPStan, it now understands that is_callable() on an array already guarantees those conditions, making the extra checks dead code that adds noise without providing safety.

Assisted-by: Claude Code (claude-sonnet-4-6)