### PR TITLE
Allow custom Quoter to be injected into CompositeHandler::create()

### DIFF
--- a/src/Handlers/CompositeHandler.php
+++ b/src/Handlers/CompositeHandler.php
@@ -12,6 +12,7 @@ namespace Respect\Stringifier\Handlers;
 
 use DateTimeInterface;
 use Respect\Stringifier\Handler;
+use Respect\Stringifier\Quoter;
 use Respect\Stringifier\Quoters\CodeQuoter;
 
 use function array_unshift;
@@ -31,10 +32,8 @@ final class CompositeHandler implements Handler
         $this->handlers = $handlers;
     }
 
-    public static function create(): self
+    public static function create(Quoter $quoter = new CodeQuoter(self::MAXIMUM_LENGTH)): self
     {
-        $quoter = new CodeQuoter(self::MAXIMUM_LENGTH);
-
         $handler = new self(
             new InfiniteNumberHandler($quoter),
             new NotANumberHandler($quoter),

--- a/tests/unit/Handlers/CompositeHandlerTest.php
+++ b/tests/unit/Handlers/CompositeHandlerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Respect\Stringifier\Handlers\CompositeHandler;
 use Respect\Stringifier\Test\Double\FakeHandler;
+use Respect\Stringifier\Test\Double\FakeQuoter;
 use Respect\Stringifier\Test\Double\LameHandler;
 use stdClass;
 
@@ -74,5 +75,14 @@ final class CompositeHandlerTest extends TestCase
     public function itShouldCreateDefaultCompositeHandler(): void
     {
         self::assertInstanceOf(CompositeHandler::class, CompositeHandler::create());
+    }
+
+    #[Test]
+    public function itShouldCreateCompositeHandlerWithTheGivenQuoter(): void
+    {
+        $quoter = new FakeQuoter();
+        $sut = CompositeHandler::create($quoter);
+
+        self::assertSame($quoter->quote('true', self::DEPTH), $sut->handle(true, self::DEPTH));
     }
 }


### PR DESCRIPTION
Previously, `create()` hardcoded `CodeQuoter` internally, giving callers no way to influence how values are quoted without rebuilding the entire handler chain manually. Now it accepts an optional `Quoter` parameter, defaulting to `CodeQuoter` to preserve backward compatibility.

This makes the factory method more extensible: users can pass whichever `Quoter` implementation works best for their context — for example, a plain quoter that omits code formatting, or a custom one with different length limits — without having to bypass `create()` entirely.

Assisted-by: Claude Code (claude-sonnet-4-6)